### PR TITLE
Add unique exits to split city branches.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,13 +37,13 @@ RAILROAD STATES is the filepath to a CSV containing which railroads are "in play
 
 Each row can take 2 formats. The less common (and simpler) one is "name; removed". For example, ``Pennsylania Railroad; removed``. In some games, home stations are treated differently whether a railroad was removed from the game (e.g. due to player counts) or if it just hasn't floated yet. This allows that distinction to be made.
 
-The format of each row is "name; trains; stations". For example, ``Baltimore & Ohio; 4 / 6, 6; C15, D6: [E5 C5], G7``. Note the use of semi-colons as column separators.
+The format of each row is "name; trains; stations". For example, ``Baltimore & Ohio; 4 / 6, 6; C15, D6: E5, G7``. Note the use of semi-colons as column separators.
 
 ``name`` is the full name of the railroad. This must match one of the railroads in the railroads.json file, which will be the same as in the game. Any railroad which doesn't show up in this file is assumed to have not yet placed its home station.
 
 ``trains`` is a comma-separated list of trains. This must match on of the trains in the trains.json file (whitespace is removed before comparison). There is no limit on the numbed of trains per railroad.
 
-``stations`` is a command-separated list of coordinates. These are checked to ensure they are cities, and that they have not gone over capacity. For each station in a split city (i.e. a city whose slots are not clustered), its branch must be indicated. The branch is made up of the coorindates of each neighbor of the station slot, surrounded by square brackets and separated by spaces. In the example above, Baltimore & Ohio has a station on D6 (Chicago), on the branch that connects C5 to E5.
+``stations`` is a command-separated list of coordinates. These are checked to ensure they are cities, and that they have not gone over capacity. For each station in a split city (i.e. a city whose slots are not clustered), either its branch or a unqiue exit must be indicated. A branch is made up of the coorindates of each neighbor of the station slot, surrounded by square brackets and separated by spaces. A unique exit is just the coordinate of the unique exit. In the example above, Baltimore & Ohio has a station on D6 (Chicago), on the branch which runs through unqiue exit E5.
 
 Private Company State (-p | --private-companies-file)
 -----------------------------------------------------

--- a/routes18xx/board.py
+++ b/routes18xx/board.py
@@ -70,8 +70,8 @@ class Board(object):
         if not space.is_city:
             raise ValueError("{} is not a city, so it cannot have a station.".format(cell))
 
-        path = tuple([self.cell(coord) for coord in branch])
-        space.add_station(railroad, path)
+        branch_cells = tuple([self.cell(coord) for coord in branch])
+        space.add_station(railroad, branch_cells)
 
     def place_token(self, coord, railroad, TokenType):
         if railroad.is_removed:

--- a/routes18xx/railroads.py
+++ b/routes18xx/railroads.py
@@ -54,11 +54,12 @@ def _split_station_entry(station_entry):
 
     coord, branch_str = station_entry.split(':')
     branch_str = branch_str.strip()
-    if not branch_str.startswith('[') or not branch_str.endswith(']'):
-        raise ValueError("Malformed station branch.")
+    if branch_str.startswith('[') and branch_str.endswith(']'):
+        branch_str = branch_str[1:-1]
+        branch = tuple([coord.strip() for coord in branch_str.split()])
+    else:
+        branch = (branch_str.strip(), )
 
-    branch_str = branch_str[1:-1]
-    branch = tuple([coord.strip() for coord in branch_str.split()])
     return coord.strip(), branch
 
 def _load_railroad_info(game):


### PR DESCRIPTION
This makes it very easy to allow users to denote a branch the same way
no matter the tile's upgrade level.