### PR TITLE
Store tiles in game object.

### DIFF
--- a/routes18xx/boardstate.py
+++ b/routes18xx/boardstate.py
@@ -1,7 +1,6 @@
 import csv
 
 from routes18xx.board import Board
-from routes18xx.tiles import get_tile
 
 
 FIELDNAMES = ("coord", "tile_id", "orientation")
@@ -21,7 +20,7 @@ def load(game, board_state_rows):
             raise ValueError("Invalid board state input. Row missing {}: {}".format(", ".join(missing), tile_args))
 
         tile_id = tile_args.pop("tile_id")
-        tile_args["tile"] = get_tile(game, tile_id)
+        tile_args["tile"] = game.tiles.get(tile_id)
         if not tile_args["tile"]:
             raise ValueError("No tile with the tile ID {} was found.".format(tile_id))
         

--- a/routes18xx/game.py
+++ b/routes18xx/game.py
@@ -2,6 +2,7 @@ import importlib
 import json
 import os
 
+from routes18xx import tiles
 from routes18xx.rules import Rules
 
 _DIR_NAME = "data"
@@ -21,13 +22,18 @@ class Game:
 
         rules = Rules.load(game_json)
 
-        return Game(game_name, game_json["phases"], game_json.get("privates_close", {}), rules)
+        game = Game(game_name, game_json["phases"], game_json.get("privates_close", {}), rules)
 
-    def __init__(self, game_name, phases, privates_close, rules):
+        game.tiles = tiles.load_all(game)
+
+        return game
+
+    def __init__(self, game_name, phases, privates_close, rules, tiles={}):
         self.name = game_name
         self.phases = phases
         self.privates_close = privates_close
         self.rules = rules
+        self.tiles = tiles
 
         self.current_phase = None
 

--- a/routes18xx/tiles.py
+++ b/routes18xx/tiles.py
@@ -4,7 +4,6 @@ import json
 
 
 _TILE_FILENAME = "tiles.json"
-_TILES = {}
 
 class Tile(object):
     @staticmethod
@@ -54,15 +53,8 @@ class Tile(object):
         self.is_stop = self.is_city or self.is_town or self.is_terminus
 
 
-def _load_all(game):
+def load_all(game):
     with open(game.get_data_file(_TILE_FILENAME)) as tiles_file:
         tiles_json = json.load(tiles_file)
 
     return {id: Tile.create(id, **args) for id, args in tiles_json.items()}
-
-def get_tile(game, tile_id):
-    global _TILES
-    if not _TILES:
-        _TILES = _load_all(game)
-
-    return _TILES.get(tile_id)


### PR DESCRIPTION
This removes another piece of global state. It was only used in one
place, which made it even simpler to move over.

Resolves #16 