### PR TITLE
Add and publicize private company info.

### DIFF
--- a/routes18xx/games/routes1846/private_companies.py
+++ b/routes18xx/games/routes1846/private_companies.py
@@ -18,6 +18,18 @@ HOME_CITIES = {
     "Michigan Southern": "C15"
 }
 
+PRIVATE_COMPANY_COORDS = {
+    "Steamboat Company": SteamboatToken.COORDS,
+    "Meat Packing Company": MeatPackingToken.COORDS,
+    "Big 4": [HOME_CITIES["Big 4"]],
+    "Michigan Southern": [HOME_CITIES["Michigan Southern"]]
+}
+
+PRIVATE_COMPANY_DEFAULT_COORDS = {
+    "Big 4": HOME_CITIES["Big 4"],
+    "Michigan Southern": HOME_CITIES["Michigan Southern"]
+}
+
 def _handle_steamboat_company(game, board, railroads, kwargs):
     owner = kwargs.get("owner")
     coord = kwargs["coord"]


### PR DESCRIPTION
Namely, the valid coordinates for private companies which place tokens, and
where (if anywhere) those tokens should be placed before the company is owned
by a railroad.

This may get moved into a JSON config file at some point, but I need to se some
more private companies to determine the best way to do it.

Resolves #22, resolves #24 