### PR TITLE
Correct support for removing railroads.

### DIFF
--- a/routes18xx/railroads.py
+++ b/routes18xx/railroads.py
@@ -84,7 +84,7 @@ def load(game, board, railroads_rows):
         trains_str = railroad_args.get("trains")
         if trains_str and trains_str.lower() == "removed":
             name = railroad_args["name"]
-            if info.get("is_removable"):
+            if not info.get("is_removable"):
                 raise ValueError("Attempted to remove a non-removable railroad.")
 
             railroad = RemovedRailroad.create(name)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_file:
 
 setup(
     name='routes-18xx',
-    version='0.5',
+    version='0.5.1',
     author="Austin Noto-Moniz",
     author_email="mathfreak65@gmail.com",
     description="Library for caluclating routes in 18xx train games.",


### PR DESCRIPTION
A typo resulted in allowing the removal of the wrong railroads, and
preventing the removal of the correct ones.