### PR TITLE
Allow closing railroads.

### DIFF
--- a/routes18xx/data/1889/game.json
+++ b/routes18xx/data/1889/game.json
@@ -4,5 +4,10 @@
         "1": "2",
         "2": "3",
         "3": "5"
+    },
+    "rules": {
+        "railroads": {
+            "can_close": false
+        }
     }
 }

--- a/routes18xx/rules.py
+++ b/routes18xx/rules.py
@@ -4,12 +4,15 @@ class Rules:
         rules_json = game_json.get("rules", {})
         return Rules(
             rules_json.get("towns", {}),
+            rules_json.get("railroads", {}),
             rules_json.get("stations", {}),
             rules_json.get("privates", {}))
 
-    def __init__(self, town_rules, station_rules, privates_rules):
+    def __init__(self, town_rules, railroad_rules, station_rules, privates_rules):
         self.towns_omit_from_limit = town_rules.get("omit_from_limit", False)
+
+        self.railroads_can_close = railroad_rules.get("can_close", True)
 
         self.stations_reserved_until = station_rules.get("reserved_until")
 
-        self.privates_close = privates_rules.get("close")
+        self.privates_close = privates_rules.get("close", {})

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as readme_file:
 
 setup(
     name='routes-18xx',
-    version='0.7.1',
+    version='0.8',
     author="Austin Noto-Moniz",
     author_email="mathfreak65@gmail.com",
     description="Library for caluclating routes in 18xx train games.",


### PR DESCRIPTION
If the game supports railroads closing, then allow them to be indicated
closed. Their reserved station slots will be forfeited.

As of the current supported games, a closed railroad is the same as a
removed railroad.

Resolves #43 