### PR TITLE
Refactor the rules into objects.

### DIFF
--- a/routes18xx/boardtile.py
+++ b/routes18xx/boardtile.py
@@ -114,7 +114,7 @@ class City(BoardSpace):
         if self.home and self.home != railroad.name and not self.has_station(self.home) and len(self.stations) + 1 >= self.capacity:
                 raise ValueError(f"{self.name} ({self.cell}) must leave a slot for {self.home}, its home railroad.")
 
-        if game.rules.stations_reserved_until and game.compare_phases(game.rules.stations_reserved_until) < 0:
+        if game.rules.stations.reserved_until and game.compare_phases(game.rules.stations.reserved_until) < 0:
             if self.reserved and self.reserved != railroad.name and not self.has_station(self.reserved) and len(self.stations) + 1 >= self.capacity:
                 raise ValueError(f"{self.name} ({self.cell}) has no open slot for its {self.reserved} reservation.")
 

--- a/routes18xx/find_best_routes.py
+++ b/routes18xx/find_best_routes.py
@@ -166,7 +166,7 @@ def _walk_routes(game, board, railroad, enter_from, cell, length, visited_paths=
         return (Route.empty(), )
 
     if tile.is_stop \
-            and (not game.rules.towns_omit_from_limit or not tile.is_town):
+            and (not game.rules.routes.omit_towns_from_limit or not tile.is_town):
         if length - 1 == 0 or (enter_from and not tile.passable(enter_from, railroad)):
             str_visited = [str(path[0]) for path in visited_paths] \
                     + ([str(enter_from)] if enter_from else []) \

--- a/routes18xx/game.py
+++ b/routes18xx/game.py
@@ -74,7 +74,7 @@ class Game:
             return 0
 
     def private_is_closed(self, name, phase=None):
-        close_phase = self.rules.privates_close.get(name)
+        close_phase = self.rules.privates.close.get(name)
         if not close_phase:
             return False
         return self.compare_phases(close_phase, phase) >= 0

--- a/routes18xx/placedtile.py
+++ b/routes18xx/placedtile.py
@@ -81,7 +81,7 @@ class PlacedTile(object):
         if self.home and self.home != railroad.name and not self.has_station(self.home) and len(self.stations) + 1 >= self.capacity:
                 raise ValueError(f"{self.name} ({self.cell}) must leave a slot for {self.home}, its home railroad.")
 
-        if game.rules.stations_reserved_until and game.compare_phases(game.rules.stations_reserved_until) < 0:
+        if game.rules.stations.reserved_until and game.compare_phases(game.rules.stations.reserved_until) < 0:
             if self.reserved and self.reserved != railroad.name and not self.has_station(self.reserved) and len(self.stations) + 1 >= self.capacity:
                 raise ValueError(f"{self.name} ({self.cell}) has no open slot for its {self.reserved} reservation.")
 

--- a/routes18xx/railroads.py
+++ b/routes18xx/railroads.py
@@ -95,7 +95,7 @@ def load(game, board, railroads_rows):
 
             railroad = RemovedRailroad.create(railroad_args["name"])
         elif trains_str == "closed":
-            if not game.rules.railroads_can_close:
+            if not game.rules.railroads.can_close:
                 raise ValueError(f"Attempted to close a railroad, although railroads cannot close in {game.name}.")
 
             railroad = ClosedRailroad.create(railroad_args["name"])

--- a/routes18xx/route.py
+++ b/routes18xx/route.py
@@ -32,7 +32,7 @@ class Route(object):
         always_include.append(max(station_cities.items(), key=lambda tile_and_value: tile_and_value[1]))
 
         path_towns = [(stop, value) for stop, value in route_stop_values.items() if stop.is_town]
-        if game.rules.towns_omit_from_limit:
+        if game.rules.routes.omit_towns_from_limit:
             always_include.extend(path_towns)
 
         # Remove from consideration the station city and any stops that should always be included.
@@ -42,7 +42,7 @@ class Route(object):
 
         # The route can collect stops only after accounting for anything marked always collect
         collect = train.collect - len(always_include)
-        if game.rules.towns_omit_from_limit:
+        if game.rules.routes.omit_towns_from_limit:
             collect += len(path_towns)
         best_stops = stop_values if collect == math.inf else dict(heapq.nlargest(collect, stop_values.items(), key=lambda stop_item: stop_item[1]))
 

--- a/routes18xx/rules.py
+++ b/routes18xx/rules.py
@@ -3,16 +3,57 @@ class Rules:
     def load(game_json):
         rules_json = game_json.get("rules", {})
         return Rules(
-            rules_json.get("towns", {}),
-            rules_json.get("railroads", {}),
-            rules_json.get("stations", {}),
-            rules_json.get("privates", {}))
+            RailroadRules.load(rules_json),
+            StationRules.load(rules_json),
+            PrivateRules.load(rules_json),
+            RouteRules.load(rules_json))
 
-    def __init__(self, town_rules, railroad_rules, station_rules, privates_rules):
-        self.towns_omit_from_limit = town_rules.get("omit_from_limit", False)
+    def __init__(self, railroad_rules, station_rules, private_rules, route_rules):
+        self.railroads = railroad_rules
+        self.stations = station_rules
+        self.privates = private_rules
+        self.routes = route_rules
 
-        self.railroads_can_close = railroad_rules.get("can_close", True)
+class RailroadRules:
+    @staticmethod
+    def load(rules_json):
+        railroad_rules_json = rules_json.get("railroads", {})
+        return RailroadRules(
+            railroad_rules_json.get("can_close", True)
+        )
 
-        self.stations_reserved_until = station_rules.get("reserved_until")
+    def __init__(self, can_close=True):
+        self.can_close = can_close
 
-        self.privates_close = privates_rules.get("close", {})
+class StationRules:
+    @staticmethod
+    def load(rules_json):
+        stations_rules_json = rules_json.get("stations", {})
+        return StationRules(
+            stations_rules_json.get("reserved_until")
+        )
+
+    def __init__(self, reserved_until=None):
+        self.reserved_until = reserved_until
+
+class PrivateRules:
+    @staticmethod
+    def load(rules_json):
+        private_rules = rules_json.get("privates", {})
+        return PrivateRules(
+            private_rules.get("close", {})
+        )
+
+    def __init__(self, close={}):
+        self.close = close
+
+class RouteRules:
+    @staticmethod
+    def load(rules_json):
+        route_rules = rules_json.get("routes", {})
+        return RouteRules(
+            route_rules.get("omit_towns_from_limit", False)
+        )
+
+    def __init__(self, omit_towns_from_limit=False):
+        self.omit_towns_from_limit = omit_towns_from_limit


### PR DESCRIPTION
It was a weird setup to have them divided into objects in the JSON, but
load them into flat attributes. I think it was to simplify the object
model, but it just makes more sense to group them into objects.