### PR TITLE
Support split towns.

### DIFF
--- a/routes18xx/boardtile.py
+++ b/routes18xx/boardtile.py
@@ -64,18 +64,35 @@ class Track(BoardSpace):
 
 class Town(BoardSpace):
     @staticmethod
-    def create(cell, name, nickname=None, upgrade_level=0, edges=[], value=0, upgrade_attrs=[], properties={}):
+    def create(cell, name, nickname=None, upgrade_level=0, edges=[], value=0, capacity=0, upgrade_attrs=[], properties={}):
+        name = ' & '.join(name) if isinstance(name, list) else name
         paths = BoardSpace._calc_paths(cell, edges)
 
-        return Town(name, nickname, cell, upgrade_level, paths, value, upgrade_attrs, properties)
+        if isinstance(capacity, dict):
+            return SplitTown.create(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties)
+        else:
+            return Town(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties)
 
-    def __init__(self, name, nickname, cell, upgrade_level, paths, value, upgrade_attrs=[], properties={}):
+    def __init__(self, name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs=[], properties={}):
         super().__init__(name, nickname, cell, upgrade_level, paths, upgrade_attrs, properties)
 
         self._value = value
+        self.capacity = capacity
 
     def value(self, game, railroad, train):
         return self._value + sum(token.value(game, railroad) for token in self.tokens)
+
+class SplitTown(Town):
+    @staticmethod
+    def create(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties):
+        split_town_capacity = SplitCity._parse_branch_dict(capacity, cell)
+
+        return SplitTown(name, nickname, cell, upgrade_level, paths, value, split_town_capacity, upgrade_attrs, properties)
+
+    def __init__(self, name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties):
+        super().__init__(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties)
+
+        self.branches = set(self.capacity.keys())
 
 class City(BoardSpace):
     @staticmethod
@@ -157,9 +174,9 @@ class SplitCity(City):
         return new_branch_dict
 
     @staticmethod
-    def create(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties):
-        split_city_capacity = {}
-        for branch_paths_str, branch_capacity in capacity.items():
+    def _parse_branch_dict(capacity, cell):
+        split_branch_dict = {}
+        for branch_paths_str, branch_value in capacity.items():
             branch_path_dict = City._calc_paths(cell, json.loads(branch_paths_str))
             branch_path_list = []
             for entrance, exits in branch_path_dict.items():
@@ -169,16 +186,21 @@ class SplitCity(City):
                     branch_paths = [(entrance, exit) for exit in exits]
                 branch_path_list.extend(tuple(branch_paths))
 
-            split_city_capacity[tuple(branch_path_list)] = branch_capacity
+            split_branch_dict[tuple(branch_path_list)] = branch_value
 
-        split_city_capacity = SplitCity._branches_with_unique_exits(split_city_capacity)
+        return SplitCity._branches_with_unique_exits(split_branch_dict)
+
+    @staticmethod
+    def create(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties):
+        split_city_capacity = SplitCity._parse_branch_dict(capacity, cell)
 
         return SplitCity(name, nickname, cell, upgrade_level, paths, value, split_city_capacity, upgrade_attrs, properties)
 
     def __init__(self, name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties):
         super().__init__(name, nickname, cell, upgrade_level, paths, value, capacity, upgrade_attrs, properties)
 
-        self.branch_to_station = {key: [] for key in self.capacity.keys()}
+        self.branches = set(self.capacity.keys())
+        self.branch_to_station = {key: [] for key in self.branches}
 
     def add_station(self, game, railroad, branch):
         if self.has_station(railroad.name):

--- a/routes18xx/find_best_routes.py
+++ b/routes18xx/find_best_routes.py
@@ -161,7 +161,7 @@ def _visited_stop_entry(tile, path, neighbor):
     new_visited_stop = {}
     if tile.is_stop:
         new_visited_stop[tile] = None
-        for branch in getattr(tile, 'branch_to_station', {}).keys():
+        for branch in getattr(tile, 'branches', set()):
             if tuple(path) in branch or (neighbor, ) in branch:
                 new_visited_stop[tile] = branch
                 break
@@ -181,7 +181,7 @@ def _walk_routes(game, board, railroad, enter_from, cell, length, visited_paths=
     if not tile or (enter_from and enter_from not in tile.paths()):
         return (Route.empty(), )
     elif tile in visited_stops:
-        if not isinstance(tile, (boardtile.SplitCity, placedtile.SplitCity)) \
+        if not isinstance(tile, (boardtile.SplitCity, placedtile.SplitCity, boardtile.SplitTown, placedtile.SplitTown)) \
                 or str(cell) in game.rules.routes.cannot_revisit \
                 or (enter_from and enter_from in set(itertools.chain.from_iterable(visited_stops[tile]))):
             return (Route.empty(), )


### PR DESCRIPTION
Create a SplitTown placetile and boardtile. In both cases, it identifies
the split town by its path groupings. If there's more than 1 grouping,
it's split.

Also add a new field to SplitCity and SplitTown called branches, which
just lists the branch paths. This is needed since SplitTown doesn't have
a concept of capcaity in which it can be encoded.

Resolves #54 